### PR TITLE
Prevent undefined key in FacebookProvider.php

### DIFF
--- a/src/Two/FacebookProvider.php
+++ b/src/Two/FacebookProvider.php
@@ -72,8 +72,10 @@ class FacebookProvider extends AbstractProvider
             'form_params' => $this->getTokenFields($code),
         ]);
         $data = json_decode($response->getBody(), true);
-        $data['expires_in'] = $data['expires'];
-        unset($data['expires']);
+        if (isset($data['expires'])) {
+            $data['expires_in'] = $data['expires'];
+            unset($data['expires']);
+        }
 
         return $data;
     }


### PR DESCRIPTION
I was getting "PHP Notice:  Undefined index: expires" in this file. The json being returned from Facebook already had a key named expires_in.

Added a check to see if that attribute is set before accessing it.