### PR TITLE
Replace zend-diactoros with laminas-diactoros

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "socialite-manager/socialite",
+    "name": "timdue/socialite",
     "description": "OAuth 1 & OAuth 2 libraries.",
     "keywords": [
         "oauth",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
-    "name": "timdue/socialite",
-    "version": "1.0.2",
+    "name": "socialite-manager/socialite",
     "description": "OAuth 1 & OAuth 2 libraries.",
     "keywords": [
         "oauth",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "timdue/socialite",
-    "version": "1.0.2",
     "description": "OAuth 1 & OAuth 2 libraries.",
     "keywords": [
         "oauth",

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "require": {
         "php": ">=7.0.0",
         "guzzlehttp/guzzle": "^6.0",
+        "laminas/laminas-diactoros": "^2.13",
         "league/oauth1-client": "^1.0",
-        "symfony/http-foundation": "^3.0",
-        "zendframework/zend-diactoros": "^1.7"
+        "symfony/http-foundation": "^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.9.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "timdue/socialite",
+    "version": "1.0.2",
     "description": "OAuth 1 & OAuth 2 libraries.",
     "keywords": [
         "oauth",

--- a/src/One/AbstractProvider.php
+++ b/src/One/AbstractProvider.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\RedirectResponse as Redirect;
 use League\OAuth1\Client\Server\Server;
 use League\OAuth1\Client\Credentials\TokenCredentials;
-use Zend\Diactoros\Response\RedirectResponse as psr7Redirect;
+use Laminas\Diactoros\Response\RedirectResponse as psr7Redirect;
 
 abstract class AbstractProvider implements ProviderInterface
 {

--- a/src/ProviderInterface.php
+++ b/src/ProviderInterface.php
@@ -13,7 +13,7 @@ interface ProviderInterface
     /**
      * Redirect the user to the authentication page for the provider.
      *
-     * @return \Zend\Diactoros\Response\RedirectResponse
+     * @return \Laminas\Diactoros\Response\RedirectResponse
      */
     public function psr7Redirect();
 

--- a/src/SocialiteManager.php
+++ b/src/SocialiteManager.php
@@ -9,7 +9,7 @@ use Socialite\Two\GoogleProvider;
 use Socialite\Two\LinkedInProvider;
 use Symfony\Component\HttpFoundation\Session\Session;
 use League\OAuth1\Client\Server\Twitter as TwitterServer;
-use Zend\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFactory;
 
 class SocialiteManager
 {

--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -8,7 +8,7 @@ use Socialite\SessionTrait;
 use Socialite\Util\A;
 use Psr\Http\Message\ServerRequestInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse as Redirect;
-use Zend\Diactoros\Response\RedirectResponse as psr7Redirect;
+use Laminas\Diactoros\Response\RedirectResponse as psr7Redirect;
 
 abstract class AbstractProvider implements ProviderInterface
 {


### PR DESCRIPTION
I made these changes to my own fork to allow me to upgrade to PHP 8.

Seems to work OK but I'm only using the "Basic Usage" not the "Advanced Usage" (PSR-7 request/response stuff) so you may want to test it before accepting the changes.